### PR TITLE
added fake_light shader with demo scene

### DIFF
--- a/enchantedtree/assets/scripts/fake_light.gd
+++ b/enchantedtree/assets/scripts/fake_light.gd
@@ -1,0 +1,25 @@
+@tool #allows for updates in the editor
+#script icon will be blue when tool is active!
+
+extends MeshInstance3D
+#fake light script
+#DO NOT DELETE!
+
+@export var mesh_pos : MeshInstance3D
+
+#maybe get all lights during level load? insert into list?
+
+#func _ready() -> void:
+	#
+	#for x in self.get_surface_override_material_count():
+		#
+		#self.get_active_material(x).set_shader_parameter("light_pos", light_pos.global_position);
+		
+
+func _process(_delta: float) -> void:
+	#add to a group?
+	
+	for x in self.get_surface_override_material_count():
+		
+		self.get_active_material(x).set_shader_parameter("light_pos", mesh_pos.global_position);
+		

--- a/enchantedtree/assets/scripts/fake_light.gd.uid
+++ b/enchantedtree/assets/scripts/fake_light.gd.uid
@@ -1,0 +1,1 @@
+uid://nxc8v500lkl

--- a/enchantedtree/assets/scripts/fake_light_csg.gd
+++ b/enchantedtree/assets/scripts/fake_light_csg.gd
@@ -1,0 +1,23 @@
+@tool #allows for updates in the editor
+#script icon will be blue when tool is active!
+
+extends CSGShape3D
+#fake light script
+#DO NOT DELETE!
+
+@export var mesh_pos : MeshInstance3D
+
+#maybe get all lights during level load? insert into list?
+
+#func _ready() -> void:
+	#
+	#for x in self.get_surface_override_material_count():
+		#
+		#self.get_active_material(x).set_shader_parameter("light_pos", light_pos.global_position);
+		
+
+func _process(_delta: float) -> void:
+	#add to a group?
+	
+	self.material.set_shader_parameter("light_pos", mesh_pos.global_position);
+		

--- a/enchantedtree/assets/scripts/fake_light_csg.gd.uid
+++ b/enchantedtree/assets/scripts/fake_light_csg.gd.uid
@@ -1,0 +1,1 @@
+uid://brlraq7kdh54n

--- a/enchantedtree/assets/shaders/fake_light.gdshader
+++ b/enchantedtree/assets/shaders/fake_light.gdshader
@@ -1,0 +1,83 @@
+// Author: Jonathan T. - RakuNana
+// Link: https://github.com/RakuNana/Shader-as-Light
+// NOTE: Shader automatically converted from Godot Engine 4.4.dev7's StandardMaterial3D.
+
+shader_type spatial;
+render_mode blend_mix, depth_draw_opaque, cull_disabled, diffuse_burley, specular_schlick_ggx;
+
+uniform vec4 albedo : source_color;
+uniform sampler2D texture_albedo : source_color, filter_linear_mipmap, repeat_enable;
+
+uniform float roughness : hint_range(0.0, 1.0);
+uniform sampler2D texture_metallic : hint_default_white, filter_linear_mipmap, repeat_enable;
+uniform vec4 metallic_texture_channel;
+uniform sampler2D texture_roughness : hint_roughness_r, filter_linear_mipmap, repeat_enable;
+
+uniform float specular : hint_range(0.0, 1.0, 0.01);
+uniform float metallic : hint_range(0.0, 1.0, 0.01);
+
+uniform sampler2D texture_heightmap : hint_default_black, filter_linear_mipmap, repeat_enable;
+uniform float heightmap_scale : hint_range(-16.0, 16.0, 0.001);
+uniform vec2 heightmap_flip;
+uniform int heightmap_min_layers : hint_range(1, 64);
+uniform int heightmap_max_layers : hint_range(1, 64);
+
+uniform vec3 uv1_scale;
+uniform vec3 uv1_offset;
+
+//added
+//size of influence of the object
+uniform float light_size = 5.0;
+//Can create a global shader in project settings, then place global in front of var
+uniform vec3 light_pos;
+//objects position in the world
+varying vec3 obj_pos;
+
+
+void vertex() {
+	UV = UV * uv1_scale.xy + uv1_offset.xy;
+	//added
+	obj_pos = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
+
+}
+
+void fragment() {
+	vec2 base_uv = UV;
+
+	{
+		// Height: Enabled
+		vec3 view_dir = normalize(normalize(-VERTEX + EYE_OFFSET) * mat3(TANGENT * heightmap_flip.x, -BINORMAL * heightmap_flip.y, NORMAL));
+		float depth = 1.0 - texture(texture_heightmap, base_uv).r;
+		vec2 ofs = base_uv - view_dir.xy * depth * heightmap_scale * 0.01;
+		base_uv = ofs;
+	}
+
+	vec4 albedo_tex = texture(texture_albedo, base_uv);
+
+	// Vertex Color Use as Albedo: Enabled
+	//If you have vertex colors active , you need to use COLOR
+	//albedo_tex *= COLOR;
+
+	//added
+	float min_dis = min(length(light_pos - obj_pos), light_size);
+
+	//added, clamps the light influence. Light/Dark balanced
+	float light_color =  clamp(light_size - min_dis,.5,2.0);
+	//mix the color , texture, and light together
+
+	//flicker
+	light_color *= sin(TIME * 15.0) * 0.025 + 0.5;
+	ALBEDO = albedo.rgb * albedo_tex.rgb * light_color * COLOR.rgb ;
+
+	float metallic_tex = dot(texture(texture_metallic, base_uv), metallic_texture_channel);
+	METALLIC = metallic_tex * metallic;
+	SPECULAR = specular;
+
+	vec4 roughness_texture_channel = vec4(1.0, 0.0, 0.0, 0.0);
+	float roughness_tex = dot(texture(texture_roughness, base_uv), roughness_texture_channel);
+	ROUGHNESS = roughness_tex * roughness;
+
+
+	//Optional, adds a flickering effect to fake light
+	//final_color *= sin(TIME * 10.0) * 0.5 + 0.5;
+}

--- a/enchantedtree/assets/shaders/fake_light.gdshader.uid
+++ b/enchantedtree/assets/shaders/fake_light.gdshader.uid
@@ -1,0 +1,1 @@
+uid://2mlxkbnr5i7m

--- a/enchantedtree/scenes/fake_light/fake_light.tscn
+++ b/enchantedtree/scenes/fake_light/fake_light.tscn
@@ -1,0 +1,339 @@
+[gd_scene load_steps=34 format=3 uid="uid://bh6oimosj1bfi"]
+
+[ext_resource type="PackedScene" uid="uid://clc5dre31iskm" path="res://addons/godot-xr-tools/xr/start_xr.tscn" id="1_soxhr"]
+[ext_resource type="PackedScene" uid="uid://yrg5yt0yvc1q" path="res://addons/godot-xr-tools/hands/scenes/collision/collision_hand.tscn" id="2_rwrjt"]
+[ext_resource type="PackedScene" uid="uid://cy03d57iyrci" path="res://addons/godot-xr-tools/hands/scenes/highpoly/left_physics_hand.tscn" id="3_nqgf4"]
+[ext_resource type="PackedScene" uid="uid://bl2nuu3qhlb5k" path="res://addons/godot-xr-tools/functions/movement_direct.tscn" id="4_c1q2d"]
+[ext_resource type="PackedScene" uid="uid://b4ysuy43poobf" path="res://addons/godot-xr-tools/functions/function_pickup.tscn" id="5_4fwl0"]
+[ext_resource type="PackedScene" uid="uid://xqimcf20s2jp" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/right_fullglove_low.tscn" id="6_ruhgs"]
+[ext_resource type="PackedScene" uid="uid://b6bk2pj8vbj28" path="res://addons/godot-xr-tools/functions/movement_turn.tscn" id="7_avik6"]
+[ext_resource type="PackedScene" uid="uid://ctltchlf2j2r4" path="res://addons/xr-simulator/XRSimulator.tscn" id="8_3wrun"]
+[ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="9_20s4e"]
+[ext_resource type="Shader" uid="uid://2mlxkbnr5i7m" path="res://assets/shaders/fake_light.gdshader" id="10_rwrjt"]
+[ext_resource type="PackedScene" uid="uid://c8l60rnugru40" path="res://addons/godot-xr-tools/objects/pickable.tscn" id="10_vtdn5"]
+[ext_resource type="Script" uid="uid://brlraq7kdh54n" path="res://assets/scripts/fake_light_csg.gd" id="11_nqgf4"]
+[ext_resource type="Script" uid="uid://nxc8v500lkl" path="res://assets/scripts/fake_light.gd" id="13_c1q2d"]
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_c1q2d"]
+animation = &"Grip"
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4fwl0"]
+animation = &"Grip"
+
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ruhgs"]
+filter_enabled = true
+filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_avik6"]
+animation = &"Grip 5"
+
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_3wrun"]
+filter_enabled = true
+filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
+
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_20s4e"]
+graph_offset = Vector2(-536, 11)
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_c1q2d")
+nodes/ClosedHand1/position = Vector2(-600, 300)
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_4fwl0")
+nodes/ClosedHand2/position = Vector2(-360, 300)
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ruhgs")
+nodes/Grip/position = Vector2(0, 20)
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_avik6")
+nodes/OpenHand/position = Vector2(-600, 100)
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_3wrun")
+nodes/Trigger/position = Vector2(-360, 20)
+node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_nqgf4"]
+frequency = 0.1409
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_c1q2d"]
+noise = SubResource("FastNoiseLite_nqgf4")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_4fwl0"]
+render_priority = 0
+shader = ExtResource("10_rwrjt")
+shader_parameter/albedo = Color(1, 1, 1, 1)
+shader_parameter/texture_albedo = SubResource("NoiseTexture2D_c1q2d")
+shader_parameter/roughness = 0.0
+shader_parameter/metallic_texture_channel = Vector4(0, 0, 0, 0)
+shader_parameter/specular = 0.0
+shader_parameter/metallic = 0.0
+shader_parameter/heightmap_scale = 0.0
+shader_parameter/heightmap_flip = Vector2(0, 0)
+shader_parameter/heightmap_min_layers = 0
+shader_parameter/heightmap_max_layers = 0
+shader_parameter/uv1_scale = Vector3(1, 1, 1)
+shader_parameter/uv1_offset = Vector3(0, 0, 0)
+shader_parameter/light_size = 5.0
+shader_parameter/light_pos = Vector3(0, 0, 0)
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_c1q2d"]
+frequency = 0.329
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_4fwl0"]
+noise = SubResource("FastNoiseLite_c1q2d")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ruhgs"]
+render_priority = 0
+shader = ExtResource("10_rwrjt")
+shader_parameter/albedo = Color(1, 1, 0, 1)
+shader_parameter/texture_albedo = SubResource("NoiseTexture2D_4fwl0")
+shader_parameter/roughness = 0.0
+shader_parameter/metallic_texture_channel = Vector4(0, 0, 0, 0)
+shader_parameter/specular = 0.0
+shader_parameter/metallic = 0.0
+shader_parameter/heightmap_scale = 0.0
+shader_parameter/heightmap_flip = Vector2(0, 0)
+shader_parameter/heightmap_min_layers = 0
+shader_parameter/heightmap_max_layers = 0
+shader_parameter/uv1_scale = Vector3(1, 10, 1)
+shader_parameter/uv1_offset = Vector3(0, 0, 0)
+shader_parameter/light_size = 5.0
+shader_parameter/light_pos = Vector3(0, 0, 0)
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_2cqfq"]
+height = 0.2
+radius = 0.1
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_yaehf"]
+top_radius = 0.1
+bottom_radius = 0.1
+height = 0.2
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_rwrjt"]
+frequency = 0.0018
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_nqgf4"]
+noise = SubResource("FastNoiseLite_rwrjt")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_c1q2d"]
+render_priority = 0
+shader = ExtResource("10_rwrjt")
+shader_parameter/albedo = Color(1, 1, 1, 1)
+shader_parameter/texture_albedo = SubResource("NoiseTexture2D_nqgf4")
+shader_parameter/roughness = 0.0
+shader_parameter/metallic_texture_channel = Vector4(0, 0, 0, 0)
+shader_parameter/specular = 0.0
+shader_parameter/metallic = 0.0
+shader_parameter/heightmap_scale = 0.0
+shader_parameter/heightmap_flip = Vector2(0, 0)
+shader_parameter/heightmap_min_layers = 0
+shader_parameter/heightmap_max_layers = 0
+shader_parameter/uv1_scale = Vector3(1, 1, 1)
+shader_parameter/uv1_offset = Vector3(0, 0, 0)
+shader_parameter/light_size = 5.0
+shader_parameter/light_pos = Vector3(0, 0, 0)
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_ruhgs"]
+frequency = 0.0831
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_avik6"]
+noise = SubResource("FastNoiseLite_ruhgs")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_3wrun"]
+render_priority = 0
+shader = ExtResource("10_rwrjt")
+shader_parameter/albedo = Color(0.699653, 0.699653, 0.699653, 1)
+shader_parameter/texture_albedo = SubResource("NoiseTexture2D_avik6")
+shader_parameter/roughness = 0.0
+shader_parameter/metallic_texture_channel = Vector4(0, 0, 0, 0)
+shader_parameter/specular = 0.0
+shader_parameter/metallic = 0.0
+shader_parameter/heightmap_scale = 0.0
+shader_parameter/heightmap_flip = Vector2(0, 0)
+shader_parameter/heightmap_min_layers = 0
+shader_parameter/heightmap_max_layers = 0
+shader_parameter/uv1_scale = Vector3(1, 1, 1)
+shader_parameter/uv1_offset = Vector3(0, 0, 0)
+shader_parameter/light_size = 5.0
+shader_parameter/light_pos = Vector3(0, 0, 0)
+
+[node name="Main" type="Node3D"]
+
+[node name="XROrigin3D" type="XROrigin3D" parent="."]
+
+[node name="XRCamera3D" type="XRCamera3D" parent="XROrigin3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.967468, 0)
+
+[node name="StartXR" parent="XROrigin3D/XRCamera3D" instance=ExtResource("1_soxhr")]
+
+[node name="XRControllerLeft" type="XRController3D" parent="XROrigin3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.29162, 0.721012, -0.659748)
+tracker = &"left_hand"
+
+[node name="XRToolsCollisionHand" parent="XROrigin3D/XRControllerLeft" node_paths=PackedStringArray("hand_skeleton") instance=ExtResource("2_rwrjt")]
+hand_skeleton = NodePath("LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D")
+
+[node name="LeftPhysicsHand" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand" instance=ExtResource("3_nqgf4")]
+
+[node name="Skeleton3D" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature" index="0"]
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
+bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
+bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
+bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
+bones/6/rotation = Quaternion(0.102925, -0.00993208, -0.00794417, 0.994608)
+bones/7/rotation = Quaternion(-0.012859, -0.0236108, -0.323258, 0.945929)
+bones/8/rotation = Quaternion(0.0120575, -0.00929194, -0.247472, 0.968775)
+bones/10/rotation = Quaternion(-0.0357539, -0.000400032, 0.00636764, 0.99934)
+bones/11/rotation = Quaternion(-0.00264964, -0.00114471, -0.125992, 0.992027)
+bones/12/rotation = Quaternion(0.0394225, 0.00193393, -0.228074, 0.972843)
+bones/13/rotation = Quaternion(-0.0123395, -0.00881294, -0.280669, 0.959685)
+bones/15/rotation = Quaternion(-0.0702656, 0.0101908, -0.0243307, 0.99718)
+bones/16/rotation = Quaternion(-0.0320634, -0.00223624, -0.0686366, 0.997124)
+bones/17/rotation = Quaternion(0.0253452, 0.00812462, -0.249005, 0.968136)
+bones/18/rotation = Quaternion(0.00252232, 0.00788073, -0.243204, 0.96994)
+bones/20/rotation = Quaternion(-0.0917369, 0.0203027, -0.010183, 0.995524)
+bones/21/rotation = Quaternion(-0.0625182, -0.00022572, -0.115393, 0.991351)
+bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
+bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
+
+[node name="BoneRoot" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="1"]
+transform = Transform3D(1, -1.83077e-05, 1.5264e-08, 1.52677e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
+
+[node name="BoneThumbMetacarpal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="2"]
+transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
+
+[node name="BoneThumbProximal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="3"]
+transform = Transform3D(0.921479, 0.383958, -0.0587628, -0.124052, 0.434264, 0.892203, 0.368087, -0.814856, 0.447796, 0.012311, 0.0475754, -0.0353648)
+
+[node name="BoneThumbDistal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="4"]
+transform = Transform3D(0.930159, 0.366844, 0.0151708, -0.154037, 0.352396, 0.923087, 0.333283, -0.860954, 0.384292, 0.028494, 0.0658787, -0.0697092)
+
+[node name="BoneIndexMetacarpal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="5"]
+transform = Transform3D(0.999165, 0.0336562, -0.0231681, 0.0231985, -0.00051113, 0.999731, 0.0336353, -0.999433, -0.00129147, -0.0100005, 0.0224317, 3.59286e-05)
+
+[node name="BoneIndexProximal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="6"]
+transform = Transform3D(0.997821, 0.0419384, -0.0509326, 0.0413169, 0.204661, 0.97796, 0.0514381, -0.977934, 0.202483, -0.00729559, 0.0223907, -0.0802861)
+
+[node name="BoneIndexMiddle" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="7"]
+transform = Transform3D(0.759851, 0.644453, -0.0854741, -0.040588, 0.178251, 0.983148, 0.648829, -0.743577, 0.161601, -0.00569705, 0.0301916, -0.117561)
+
+[node name="BoneIndexDistal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="8"]
+transform = Transform3D(0.356468, 0.927111, -0.115741, -0.109286, 0.164404, 0.98032, 0.927894, -0.336804, 0.159925, 0.0145038, 0.035779, -0.140869)
+
+[node name="BoneMiddleMetacarpal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="9"]
+transform = Transform3D(0.999918, -0.0127165, -0.00125617, 0.000365489, -0.0698022, 0.997561, -0.0127732, -0.99748, -0.0697919, -0.0100005, 0.00355416, 3.59286e-05)
+
+[node name="BoneMiddleProximal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="10"]
+transform = Transform3D(0.971345, 0.237654, -0.00293004, 0.0207339, -0.0724503, 0.997156, 0.236766, -0.968644, -0.0753018, -0.0110237, -0.00206236, -0.0802245)
+
+[node name="BoneMiddleMiddle" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="11"]
+transform = Transform3D(0.764922, 0.643161, -0.0351718, 0.0290327, 0.0201225, 0.999376, 0.643468, -0.765466, -0.00328059, -0.000328456, -0.00532286, -0.123817)
+
+[node name="BoneMiddleDistal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="12"]
+transform = Transform3D(0.297115, 0.95453, -0.0243818, 0.0374454, 0.0138673, 0.999202, 0.954107, -0.297791, -0.0316226, 0.0205207, -0.00467056, -0.148631)
+
+[node name="BoneRingMetacarpal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="13"]
+transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.990149, 0.0499098, -0.989175, -0.137988, -0.0100005, -0.0130734, 3.59304e-05)
+
+[node name="BoneRingProximal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="14"]
+transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
+
+[node name="BoneRingMiddle" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="15"]
+transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778394, -0.0314857, -0.111722)
+
+[node name="BoneRingDistal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="16"]
+transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
+
+[node name="BonePinkyMetacarpal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="17"]
+transform = Transform3D(0.998969, 0.0165318, 0.0422887, -0.0385953, -0.181426, 0.982647, 0.0239172, -0.983265, -0.180601, -4.58211e-07, -0.0299734, 3.59304e-05)
+
+[node name="BonePinkyProximal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="18"]
+transform = Transform3D(0.969212, 0.239304, 0.0579745, 0.0185535, -0.305761, 0.951928, 0.245527, -0.921544, -0.300787, 0.00108587, -0.0418952, -0.0645756)
+
+[node name="BonePinkyMiddle" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="19"]
+transform = Transform3D(0.699331, 0.713816, 0.0374602, 0.103947, -0.153407, 0.982681, 0.707199, -0.683325, -0.181481, 0.00901247, -0.0520231, -0.0951004)
+
+[node name="BonePinkyDistal" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L/Armature/Skeleton3D" index="20"]
+transform = Transform3D(0.340891, 0.939844, 0.0220291, 0.162162, -0.081867, 0.983362, 0.926011, -0.331647, -0.180315, 0.0218786, -0.0547881, -0.107417)
+
+[node name="AnimationTree" parent="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand" index="1"]
+root_node = NodePath("../Hand_Nails_L")
+tree_root = SubResource("AnimationNodeBlendTree_20s4e")
+
+[node name="MovementDirect" parent="XROrigin3D/XRControllerLeft" instance=ExtResource("4_c1q2d")]
+strafe = true
+
+[node name="FunctionPickup" parent="XROrigin3D/XRControllerLeft" instance=ExtResource("5_4fwl0")]
+
+[node name="XRController3D" type="XRController3D" parent="XROrigin3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.314656, 0.719788, -0.991062)
+tracker = &"right_hand"
+
+[node name="XRToolsCollisionHand" parent="XROrigin3D/XRController3D" instance=ExtResource("2_rwrjt")]
+
+[node name="RightHand" parent="XROrigin3D/XRController3D/XRToolsCollisionHand" instance=ExtResource("6_ruhgs")]
+
+[node name="MovementTurn" parent="XROrigin3D/XRController3D" instance=ExtResource("7_avik6")]
+turn_mode = 1
+
+[node name="FunctionPickup" parent="XROrigin3D/XRController3D" instance=ExtResource("5_4fwl0")]
+
+[node name="XRSimulator" parent="XROrigin3D" instance=ExtResource("8_3wrun")]
+disable_xr_in_editor = true
+
+[node name="PlayerBody" parent="XROrigin3D" instance=ExtResource("9_20s4e")]
+
+[node name="Floor" type="CSGBox3D" parent="." node_paths=PackedStringArray("mesh_pos")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
+use_collision = true
+size = Vector3(30, 1, 30)
+material = SubResource("ShaderMaterial_4fwl0")
+script = ExtResource("11_nqgf4")
+mesh_pos = NodePath("../PickableObject/MeshInstance3D")
+
+[node name="CSGBox3D" type="CSGBox3D" parent="Floor" node_paths=PackedStringArray("mesh_pos")]
+transform = Transform3D(0.970922, 0, 0.239398, 0, 1, 0, -0.239398, 0, 0.970922, 0, 0.939461, 0)
+operation = 2
+size = Vector3(30, 1, 3)
+material = SubResource("ShaderMaterial_ruhgs")
+script = ExtResource("11_nqgf4")
+mesh_pos = NodePath("../../PickableObject/MeshInstance3D")
+
+[node name="Treetrunk" type="CSGCylinder3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.07843, 0, -1.96035)
+use_collision = true
+radius = 0.2
+height = 5.0
+
+[node name="Stump" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.0183296, -2.24788)
+use_collision = true
+size = Vector3(1, 1.2, 1)
+
+[node name="PickableObject" parent="." instance=ExtResource("10_vtdn5")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.13298, -2.14122)
+
+[node name="CollisionShape3D2" type="CollisionShape3D" parent="PickableObject"]
+transform = Transform3D(0.980768, 0.195176, 0, -0.195176, 0.980768, 0, 0, 0, 1, 0, -0.256298, 0.277325)
+shape = SubResource("CylinderShape3D_2cqfq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="PickableObject" node_paths=PackedStringArray("mesh_pos")]
+transform = Transform3D(0.980768, 0.195176, 0, -0.195176, 0.980768, 0, 0, 0, 1, 0, -0.256298, 0.277325)
+mesh = SubResource("CylinderMesh_yaehf")
+surface_material_override/0 = SubResource("ShaderMaterial_c1q2d")
+script = ExtResource("13_c1q2d")
+mesh_pos = NodePath(".")
+
+[node name="CSGSphere3D" type="CSGSphere3D" parent="."]
+transform = Transform3D(-0.969029, 0, -0.246948, 0, 1, 0, 0.246948, 0, -0.969029, -7.38143, 0.842078, -11.2087)
+use_collision = true
+radius = 6.0
+
+[node name="CSGSphere3D" type="CSGSphere3D" parent="CSGSphere3D" node_paths=PackedStringArray("mesh_pos")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.21823)
+operation = 2
+radius = 5.0
+material = SubResource("ShaderMaterial_3wrun")
+script = ExtResource("11_nqgf4")
+mesh_pos = NodePath("../../PickableObject/MeshInstance3D")
+
+[node name="CSGCylinder3D" type="CSGCylinder3D" parent="CSGSphere3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.39658, 3.30916, -0.0826082)
+operation = 2
+radius = 2.0
+
+[editable path="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand"]
+[editable path="XROrigin3D/XRControllerLeft/XRToolsCollisionHand/LeftPhysicsHand/Hand_Nails_L"]


### PR DESCRIPTION
this adds a fake light shader which actualy is partialy using light but it is reduced a lot to save on performance, in the scene itself there is no light source

the shader is added to the surface/material of the meshinstance3d or csgshape3d node along with a script which points to the light source, this could be automated probably

and last but not least this whole thing is from
Jonathan T. -  RakuNana
https://github.com/RakuNana/Shader-as-Light